### PR TITLE
removing unnecessary cd in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
     - cd Cython-0.18
     - sudo python$PYSUF setup.py install
     # Regreg
+    - cd ..
     - $PYTHON setup.py build
     - sudo $PYTHON setup.py install
 script:


### PR DESCRIPTION
After code cleanup travis test errors because code directory does not exist.
