### PR TITLE
BF: fix imports I broke by moving the atom tests

### DIFF
--- a/regreg/tests/test_container.py
+++ b/regreg/tests/test_container.py
@@ -5,7 +5,7 @@ from copy import copy
 import scipy.optimize
 
 import regreg.api as rr
-from atoms.test_seminorms import all_close 
+from ..atoms.tests.test_seminorms import all_close
 
 def test_lasso():
     '''

--- a/regreg/tests/test_factored_matrix.py
+++ b/regreg/tests/test_factored_matrix.py
@@ -4,7 +4,7 @@ import regreg.affine.factored_matrix as FM
 from regreg.affine import power_L, todense
 from regreg.atoms.projl1_cython import projl1
 from regreg.api import identity_quadratic
-from atoms.test_seminorms import all_close
+from ..atoms.tests.test_seminorms import all_close
 
 X = np.random.standard_normal((100, 50))
 X[:,:7] *= 5

--- a/regreg/tests/test_simple.py
+++ b/regreg/tests/test_simple.py
@@ -1,12 +1,13 @@
+from copy import copy
+
 import numpy as np
 
 import regreg.api as rr
 from regreg.problems.simple import gengrad
+
 import nose.tools as nt
 
-from atoms.test_seminorms import all_close
-
-from copy import copy
+from ..atoms.tests.test_seminorms import all_close
 
 def test_simple():
     Z = np.random.standard_normal(100) * 4

--- a/regreg/tests/test_simple_block.py
+++ b/regreg/tests/test_simple_block.py
@@ -1,13 +1,14 @@
+from copy import copy
+
 import numpy as np
 
 import regreg.api as rr
 from regreg.problems.simple import gengrad
+
 import nose.tools as nt
 
-from atoms.test_seminorms import all_close
+from ..atoms.tests.test_seminorms import all_close
 
-
-from copy import copy
 
 def test_simple():
     Z = np.random.standard_normal((10,10)) * 4


### PR DESCRIPTION
When I moved the atom tests from the regreg/tests directory I didn't realize
that other tests were importing from them.  Fix these imports to find the
atom tests all_close routine.

Maybe atoms.tests.test_seminorms.all_close should be a utility function 
somewhere not in tests?
