### PR TITLE
MRG: fix and refactor dependency checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ source = regreg
 include = */regreg/*
 omit =
     */setup.py
+    */regreg/_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ matrix:
         - INSTALL_TYPE=setup
     - python: 2.7
       env:
+        # Sdist install should collect all dependencies
         - INSTALL_TYPE=sdist
-        # Cython needed to run setup.py sdist, scipy for tests
-        - DEPENDS="cython==0.18 numpy==1.6.0 scipy==0.9.0"
+        - DEPENDS=
     - python: 2.7
       env:
+        # Wheel install should collect all dependencies
         - INSTALL_TYPE=wheel
-        # Cython needed to build binary wheel, scipy for tests
-        - DEPENDS="cython==0.18 numpy==1.6.0 scipy==0.9.0"
+        - DEPENDS=
     - python: 2.7
       env:
         - INSTALL_TYPE=requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,6 @@ matrix:
       env:
         - INSTALL_TYPE=requirements
         - DEPENDS=
-    # test against pre-release builds
-    - python: 2.7
-      env:
-        - EXTRA_PIP_FLAGS="--pre"
 before_install:
     - source travis-tools/utils.sh
     - travis_before_install

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -325,3 +325,36 @@ def read_vars_from(ver_file):
     with open(ver_file, 'rt') as fobj:
         exec(fobj.read(), ns)
     return Bunch(ns)
+
+
+def make_np_ext_builder(build_ext_class):
+    """ Override input `build_ext_class` to add numpy includes to extension
+
+    This is useful to delay call of ``np.get_include`` until the extension is
+    being built.
+
+    Parameters
+    ----------
+    build_ext_class : class
+        Class implementing ``distutils.command.build_ext.build_ext`` interface,
+        with a ``build_extensions`` method.
+
+    Returns
+    -------
+    np_build_ext_class : class
+        A class with similar interface to
+        ``distutils.command.build_ext.build_ext``, that adds libraries in
+        ``np.get_include()`` to include directories of extension.
+    """
+    class NpExtBuilder(build_ext_class):
+
+        def build_extensions(self):
+            """ Hook into extension building to add np include dirs
+            """
+            # Delay numpy import until last moment
+            import numpy as np
+            for ext in self.extensions:
+                ext.include_dirs.append(np.get_include())
+            build_ext_class.build_extensions(self)
+
+    return NpExtBuilder

--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -291,7 +291,7 @@ class SetupDependency(object):
         # Using setuptools; add packages to given section of
         # setup/install_requires, unless it's a heavy dependency for which we
         # already have an acceptable importable version.
-        if self.heavy and ver_err_msg:
+        if self.heavy and ver_err_msg is None:
             return
         new_req = '{0}>={1}'.format(self.import_name, self.min_ver)
         old_reqs = setuptools_kwargs.get(self.req_type, [])


### PR DESCRIPTION
Fix a bug in checking for heavy dependency, that meant that they were not
getting installed.

Remove setup.py dependency on numpy so pip can install regreg into fresh
virtualenv without numpy yet installed.