### PR TITLE
BUG: fix indexing errors with range objects

### DIFF
--- a/regreg/affine/factored_matrix.py
+++ b/regreg/affine/factored_matrix.py
@@ -348,7 +348,7 @@ def partial_svd(transform,
         if debug and itercount > 0:
             print(itercount, singular_rel_change,
                   np.sum(np.fabs(singular_values)>1e-12),
-                  np.fabs(singular_values[range(np.min([5,len(singular_values)]))]))
+                  np.fabs(singular_values[np.arange(np.min([5,len(singular_values)]))]))
         V, _ = np.linalg.qr(transform.adjoint_map(U))
         X_V = transform.linear_map(V)
         U, R = np.linalg.qr(X_V)

--- a/regreg/smooth/tests/test_glm.py
+++ b/regreg/smooth/tests/test_glm.py
@@ -20,14 +20,14 @@ def test_logistic():
         L.hessian(np.zeros(L.shape))
 
         Lcp = copy(L)
-        L_sub = L.subsample(range(5))
+        L_sub = L.subsample(np.arange(5))
 
         # check that subsample is getting correct answer
 
-        Xsub = X[range(5)]
-        Ysub = Y[range(5)]
+        Xsub = X[np.arange(5)]
+        Ysub = Y[np.arange(5)]
         if T is not None:
-            Tsub = T[range(5)]
+            Tsub = T[np.arange(5)]
             T_num = T
         else:
             Tsub = np.ones(5)
@@ -87,7 +87,7 @@ def test_poisson():
     L.hessian(np.zeros(L.shape))
 
     Lcp = copy(L)
-    L_sub = L.subsample(range(5))
+    L_sub = L.subsample(np.arange(5))
 
     np.testing.assert_allclose(L.gradient(np.zeros(L.shape)),
                                X.T.dot(1 - Y))
@@ -105,8 +105,8 @@ def test_poisson():
 
     # check that subsample is getting correct answer
 
-    Xsub = X[range(5)]
-    Ysub = Y[range(5)]
+    Xsub = X[np.arange(5)]
+    Ysub = Y[np.arange(5)]
 
     Lsub2 = glm.poisson(Xsub, Ysub)
     beta = np.ones(L.shape)
@@ -140,10 +140,10 @@ def test_gaussian():
     L = glm.gaussian(X, Y)
     L.hessian(np.zeros(L.shape))
     L.smooth_objective(np.zeros(L.shape), 'both')
-    L_sub = L.subsample(range(5))
+    L_sub = L.subsample(np.arange(5))
 
-    Xs = X[range(5)]
-    Ys = Y[range(5)]
+    Xs = X[np.arange(5)]
+    Ys = Y[np.arange(5)]
 
     beta = np.ones(5)
     value_sub = 0.5 * np.linalg.norm(Ys - Xs.dot(beta))**2
@@ -172,8 +172,8 @@ def test_gaussian():
 
     # check that subsample is getting correct answer
 
-    Xsub = X[range(5)]
-    Ysub = Y[range(5)]
+    Xsub = X[np.arange(5)]
+    Ysub = Y[np.arange(5)]
 
     Lsub2 = glm.gaussian(Xsub, Ysub)
     beta = np.ones(L.shape)
@@ -211,7 +211,7 @@ def test_huber():
     L.smooth_objective(np.zeros(L.shape), 'both')
 
     Lcp = copy(L)
-    L_sub = L.subsample(range(5))
+    L_sub = L.subsample(np.arange(5))
 
     L.gradient(np.zeros(L.shape))
     nt.assert_raises(NotImplementedError, L.hessian, np.zeros(L.shape))

--- a/regreg/smooth/tests/test_logistic.py
+++ b/regreg/smooth/tests/test_logistic.py
@@ -87,10 +87,10 @@ def test_logistic_offset():
     vals = solver2.fit(tol=1e-12)
     solution2 = solver2.composite.coefs
 
-    ind = range(1,p+1)
+    ind = np.arange(1,p+1)
 
-    print(solution1[range(5)])
-    print(solution2[range(5)])
+    print(solution1[np.arange(5)])
+    print(solution2[np.arange(5)])
 
     npt.assert_array_almost_equal(solution1[ind], solution2[ind], 3)
     npt.assert_almost_equal(solution1[0]-diff,solution2[0], 2)


### PR DESCRIPTION
With Python 3.4, we are getting indexing errors trying to index into
array with range objects - e.g.:

```
    idx_bool[idx] = 1
IndexError: unsupported iterator index
```

where `idx` is a range object.  See:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/211972130/log.txt

Use np.arange instead of range.