### PR TITLE
making sure R tests are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,7 @@ script:
         sudo apt-get update
         sudo apt-get install -y r-base r-base-dev
         pip install -r test-requirements.txt
+        pip install -e .
         nosetests $DOCTEST_ARGS --verbose regreg
       else
         # Doctests only on platforms that have compatible fp output

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ script:
         sudo add-apt-repository -y ppa:marutter/rrutter
         sudo apt-get update
         sudo apt-get install -y r-base r-base-dev
-	pip install -r test-requirements.txt
+        pip install -r test-requirements.txt
         nosetests $DOCTEST_ARGS --verbose regreg
       else
         # Doctests only on platforms that have compatible fp output

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ script:
         # Now build the full docs
         make clean
         make html
-      elif [ "$R_TESTS"]; then
+      elif [ "$R_TESTS" ]; then
         sudo apt-get install software-properties-common
         sudo add-apt-repository -y ppa:marutter/rrutter
         sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,16 @@ matrix:
       dist: trusty
       env:
         - DOC_BUILD=1
+    - python: 3.5
+      sudo: true
+      dist: trusty
+      env:
+        - R_TESTS=1
+    - python: 2.7
+      sudo: true
+      dist: trusty
+      env:
+        - R_TESTS=1
     - os: osx
       osx_image: xcode7.3
       language: generic
@@ -138,6 +148,13 @@ script:
         # Now build the full docs
         make clean
         make html
+      elif [ "$R_TESTS"]; then
+        sudo apt-get install software-properties-common
+        sudo add-apt-repository -y ppa:marutter/rrutter
+        sudo apt-get update
+        sudo apt-get install -y r-base r-base-dev
+	pip install -r test-requirements.txt
+        nosetests $DOCTEST_ARGS --verbose regreg
       else
         # Doctests only on platforms that have compatible fp output
         if [ `uname` == "Darwin" ] ||

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,12 +1,11 @@
 # Requirements for building docs
 # Check these dependencies against doc/conf.py
 -r dev-requirements.txt
+-r test-requirements.txt
 sphinx>=1.4
 numpydoc
 matplotlib
 texext
-rpy2
 nb2plots
 sklearn
-# for PHreg
-statsmodels
+

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -8,3 +8,5 @@ texext
 rpy2
 nb2plots
 sklearn
+# for PHreg
+statsmodels

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+# Requirements to ensure that all tests are run
+# rpy2 allows comparison with R's output
+# statsmodels enables Cox proportional hazards model regression and a check with R
+rpy2
+statsmodels


### PR DESCRIPTION
Without forcing rpy2 to be installed, the tests in

regreg.smooth.tests.test_compareR

were not being run.

Added two test requirements so that we can run the tests -- statsmodels provides likelihood for Cox proportional hazards model.